### PR TITLE
fixed regex on rfilter to allow not only integer numbers but also float numbers

### DIFF
--- a/app_site/carroceiro/urls.py
+++ b/app_site/carroceiro/urls.py
@@ -13,5 +13,5 @@ urlpatterns = [
     url(r'^(?P<id>[0-9]+)/$', views.CarroceiroDetail.as_view(), name='carroceiro-detail'),
     # ex: /carroceiro/rfilter/<lat>&<long>&<radius>
     # ex: /carroceiro/rfilter/-23.5374089,-46.6399287,10/
-    url(r'^rfilter/(?P<lat_1>[-|+]?\d+\.\d+),(?P<long_1>[-|+]?\d+\.\d+),(?P<radius>\d+)/$', views.CarroceiroRadiusFilter.as_view(), name='carroceiro-radius-filter')
+    url(r'^rfilter/(?P<lat_1>[-|+]?\d+\.\d+),(?P<long_1>[-|+]?\d+\.\d+),(?P<radius>\d+\.?\d{0,5})/$', views.CarroceiroRadiusFilter.as_view(), name='carroceiro-radius-filter')
 ]


### PR DESCRIPTION
Consertei a regex do "rfilter" para permitir float numbers! Todos os testes de integracao passaram:
![rfilter_floating_regex](https://cloud.githubusercontent.com/assets/1010796/12218807/f6502f08-b710-11e5-8fd1-de773e101a44.png)

(venv)arcanjo@ubuntu:~/PycharmProjects/pimpapp-api$ py.test integration_tests/tests.py -v
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.4.3+, pytest-2.8.2, py-1.4.30, pluggy-0.3.1 -- /home/arcanjo/PycharmProjects/pimpapp-api/venv/bin/python3.4
cachedir: integration_tests/.cache
rootdir: /home/arcanjo/PycharmProjects/pimpapp-api/integration_tests, inifile: 
collected 10 items 

integration_tests/tests.py::TestCarroceirosListViews::test_get PASSED
integration_tests/tests.py::TestCarroceirosListViews::test_post_valid_carroceiro PASSED
integration_tests/tests.py::TestCarroceirosListViews::test_post_invalid_carroceiro PASSED
integration_tests/tests.py::TestCarroceiroFilter::test_get_filter_by_phone PASSED
integration_tests/tests.py::TestCarroceiroDetail::test_valid_get PASSED
integration_tests/tests.py::TestCarroceiroDetail::test_invalid_get PASSED
integration_tests/tests.py::TestCarroceiroDetail::test_put PASSED
integration_tests/tests.py::TestCarroceiroDetail::test_invalid_put PASSED
integration_tests/tests.py::TestCarroceiroDetail::test_delete PASSED
integration_tests/tests.py::TestCarroceiroDetail::test_invalid_delete PASSED

======================================================================================== 10 passed in 1.30 seconds ========================================================================================
(venv)arcanjo@ubuntu:~/PycharmProjects/pimpapp-api$ 
