### PR TITLE
Gerando relatório por catadores selecionados

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ target/
 venv/
 env/
 env34/
+.vEnv/
 
 # cache results from py.test
 integration_test/.cache

--- a/app_site/templates/admin/api/catador/change_list.html
+++ b/app_site/templates/admin/api/catador/change_list.html
@@ -61,7 +61,7 @@
           {% endblock %}
             <li>
               <a href="{% url 'export_catadores_csv' %}" class="viewsitelink">
-                Exportar para Excel
+                Exportar todos para Excel
               </a>
             </li>
         </ul>


### PR DESCRIPTION
- A pedido do Breno para atender uma necessidade interna do Cataki será necessário gerar um relatório com os catadores filtrados na administração. Anteriormente era possível apenas gerar um relatório completo com todos os catadores, independente do filtro. 
A partir de agora o usuário deverá marcar os checkboxs para selecionar os catadores desejados. Lembrando que na administração é possível "marcar todos", o que facilita esse trabalho.
